### PR TITLE
Adding error handling, unit tests, integration tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    testEnvironment: 'node',
+};
+  

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "# Information: Author: Diego Vazquez Date: 03/29/2024 email: dvazqueb11@gmail.com",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "TEST_PORT=3001 jest --coverage",
+    "test:watch": "jest --watch",
     "start": "node src/app.js",
     "dev": "nodemon src/app.js"
   },

--- a/src/api/weather.js
+++ b/src/api/weather.js
@@ -3,13 +3,23 @@ const router = express.Router();
 const weatherService = require('../services/weatherService');
 
 router.get('/', async (req, res) => {
+    const { lat, lon } = req.query;
+  
+    if (!lat || !lon) {
+      return res.status(400).json({ message: "Latitude and longitude are required." });
+    }
+  
+    if (isNaN(lat) || isNaN(lon)) {
+      return res.status(400).json({ message: "Latitude and longitude must be valid numbers." });
+    }
+  
     try {
-        const { lat, lon } = req.query;
-        const weatherData = await weatherService.getWeather(lat, lon);
-        res.json(weatherData);
-    } catch (err) {
-        res.status(500).json({ message: err.message });
+      const weatherData = await weatherService.getWeather(lat, lon);
+      res.json(weatherData);
+    } catch (error) {
+      res.status(500).json({ message: error.message });
     }
 });
+  
 
 module.exports = router;

--- a/src/app.js
+++ b/src/app.js
@@ -2,13 +2,13 @@ const express = require('express');
 const weatherRoutes = require('./api/weather');
 
 const app = express();
-const port = 3000;
 
 app.use(express.json());
 app.use('/api/weather', weatherRoutes);
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
+if (require.main === module) {
+    const port = process.env.TEST_PORT || 3000;
+    app.listen(port, () => console.log(`Server listening on port ${port}`));
+}
 
 module.exports = app; // Export for testing

--- a/src/services/weatherService.js
+++ b/src/services/weatherService.js
@@ -6,10 +6,19 @@ const BASE_URL = 'https://api.openweathermap.org/data/3.0/onecall';
 
 const getWeather = async (lat, lon) => {
     try {
-        const response = await axios.get(`${BASE_URL}?lat=${lat}&lon=${lon}&appid=${openWeatherApiKey}&units=metric`)
+        const response = await axios.get(`${BASE_URL}?lat=${lat}&lon=${lon}&appid=${openWeatherApiKey}&units=metric`);
+        if (response.status !== 200) {
+            throw new Error(`Failed to retrieve weather data: ${response.status} ${response.statusText}`);
+        }
         return utils.processWeatherData(response.data);
     } catch (error) {
-        throw new Error('Failed to retrieve data')
+        if (error.response && error.response.status === 401) {
+          throw new Error('Invalid API Key');
+        } else if (error.response && error.response.status === 429) {
+          throw new Error('API Limit Reached');
+        } else {
+          throw new Error('Failed to retrieve weather data');
+        }
     }
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,9 @@
 const processWeatherData = (data) => {
+
+    if (!data || !data.current || !data.current.weather) {
+        throw new Error('Invalid weather data format');
+    }
+    
     const { current, alerts } = data;
     const weather = {
         temperature: current.temp,

--- a/tests/integration/weatherApi.test.js
+++ b/tests/integration/weatherApi.test.js
@@ -1,0 +1,40 @@
+const request = require('supertest');
+const app = require('../../src/app'); 
+
+describe('GET /api/weather', () => {
+    it('returns an error for missing query parameters', async () => {
+        const response = await request(app)
+          .get('/api/weather')
+          .expect('Content-Type', /json/)
+          .expect(400);
+    
+        expect(response.body).toHaveProperty('message', 'Latitude and longitude are required.');
+      });
+    
+    it('returns weather data for valid requests', async () => {
+        // This assumes you have a way to mock the external API call within your application
+        // For real testing, you might hit a test instance of the API or mock the service layer
+        const response = await request(app)
+          .get('/api/weather?lat=40.712776&lon=-74.005974')
+          .expect('Content-Type', /json/)
+          .expect(200);
+    
+        // Validate the structure of your weather data response
+        expect(response.body).toEqual({
+          temperature: expect.any(Number),
+          condition: expect.any(String),
+          temperatureStatus: expect.any(String),
+          alerts: expect.any(Array)
+        });
+    });
+    
+    it('handles unexpected input types', async () => {
+        const response = await request(app)
+          .get('/api/weather?lat=forty&lon=-seventy-four')
+          .expect('Content-Type', /json/)
+          .expect(400);
+    
+        expect(response.body).toHaveProperty('message', 'Latitude and longitude must be valid numbers.');
+    });
+});
+

--- a/tests/unit/weatherService.test.js
+++ b/tests/unit/weatherService.test.js
@@ -1,0 +1,65 @@
+const axios = require('axios');
+const MockAdapter = require('axios-mock-adapter');
+const { getWeather } = require('../../src/services/weatherService');
+const { openWeatherApiKey } = require('../../src/config');
+
+const mock = new MockAdapter(axios);
+
+// Use case for fetching and processing data
+describe('weatherService', () => {
+    it('fetched and processes weather data correctly', async () => {
+        const mockData = {
+            current : {
+                temp: 15,
+                weather: [{main: 'Clouds'}],
+            },
+            alerts: []
+        };
+
+        mock.onGet(`https://api.openweathermap.org/data/3.0/onecall?lat=40.712776&lon=-74.005974&appid=${openWeatherApiKey}&units=metric`).reply(200, mockData);
+
+        const weather = await getWeather(40.712776, -74.005974);
+        expect(weather.temperature).toBe(15);
+        expect(weather.condition).toBe('Clouds');
+        expect(weather.temperatureStatus).toBe('moderate');
+        expect(weather.alerts).toEqual([]);
+    });
+
+    it('handles network errors gracefully', async () => {
+        mock.onGet(`https://api.openweathermap.org/data/3.0/onecall?lat=40.712776&lon=-74.005974&appid=${openWeatherApiKey}&units=metric`).networkError();
+      
+        await expect(getWeather(40.712776, -74.005974)).rejects.toThrow('Failed to retrieve weather data');
+      });
+      
+    it('handles non-200 status codes from the API', async () => {
+        mock.onGet(`https://api.openweathermap.org/data/3.0/onecall?lat=40.712776&lon=-74.005974&appid=${openWeatherApiKey}&units=metric`).reply(500, { message: 'Internal Server Error' });
+      
+        await expect(getWeather(40.712776, -74.005974)).rejects.toThrow('Failed to retrieve weather data');
+    });
+
+});
+
+describe('temperature category edge cases', () => {
+    const testCases = [
+      { temp: -1, expected: 'cold' },
+      { temp: 0, expected: 'cold' },
+      { temp: 15, expected: 'moderate' },
+      { temp: 25, expected: 'hot' },
+    ];
+  
+    testCases.forEach(({ temp, expected }) => {
+      it(`categorizes ${temp} degrees as ${expected}`, async () => {
+        mock.onGet(`https://api.openweathermap.org/data/3.0/onecall?lat=40.712776&lon=-74.005974&appid=${openWeatherApiKey}&units=metric`).reply(200, {
+          current: {
+            temp,
+            weather: [{ main: 'Clear' }],
+          },
+          alerts: []
+        });
+  
+        const weatherData = await getWeather(40.712776, -74.005974);
+        expect(weatherData.temperatureStatus).toEqual(expected);
+      });
+    });
+  });
+  


### PR DESCRIPTION
This PR contains adding error handling, unit and integration testing, a work around to allow server to be listen on port 3000 just when running app.js and not when importing in test files.

Added a port for testing = 3001
Add coverage to Jest to show test coverage analytics.

```
 PASS  tests/unit/weatherService.test.js
 PASS  tests/integration/weatherApi.test.js
--------------------|---------|----------|---------|---------|-------------------
File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------|---------|----------|---------|---------|-------------------
All files           |   83.92 |       80 |   66.66 |    84.9 |                   
 src                |      70 |       25 |       0 |   77.77 |                   
  app.js            |      70 |       25 |       0 |   77.77 | 10-11             
 src/api            |   92.85 |      100 |     100 |   92.85 |                   
  weather.js        |   92.85 |      100 |     100 |   92.85 | 20                
 src/config         |     100 |      100 |     100 |     100 |                   
  index.js          |     100 |      100 |     100 |     100 |                   
 src/services       |   81.25 |       70 |     100 |   81.25 |                   
  weatherService.js |   81.25 |       70 |     100 |   81.25 | 11,16,18          
 src/utils          |   85.71 |     92.3 |   66.66 |   83.33 |                   
  index.js          |   85.71 |     92.3 |   66.66 |   83.33 | 4,12              
--------------------|---------|----------|---------|---------|-------------------

Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        0.813 s, estimated 1 s
Ran all test suites.
```
